### PR TITLE
Buffer.from & Stringifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ class kmsSecretsPlugin {
         KeyId: keyId, // The identifier of the CMK to use for encryption.
         // You can use the key ID or Amazon Resource Name (ARN) of the CMK,
         // or the name or ARN of an alias that refers to the CMK.
-        Plaintext: Buffer(this.options.value), // eslint-disable-line new-cap
+        Plaintext: Buffer.from(String(this.options.value)), // eslint-disable-line new-cap
       }).promise()
       .then((data) => {
         kmsSecrets.secrets[this.options.name] = data.CiphertextBlob.toString('base64');
@@ -173,7 +173,7 @@ class kmsSecretsPlugin {
             AWS.config.update({ region });
             const kms = new AWS.KMS();
             kms.decrypt({
-              CiphertextBlob: Buffer(secrets[varName], 'base64'), // eslint-disable-line new-cap
+              CiphertextBlob: Buffer.from(secrets[varName], 'base64'), // eslint-disable-line new-cap
             }).promise()
             .then(data => {
               const secret = String(data.Plaintext);


### PR DESCRIPTION
This PR fixes two bugs I encountered:

1. `this.options.value` is automatically transformed into a `Number` if you pass in a `Number`. `Number` is an unacceptable type for `Buffer` operations.
2. `Buffer` is deprecated and it will throw an un-understandable error if you pass in a `Number`.